### PR TITLE
disable AF_ALG engine for Debian Jessie

### DIFF
--- a/build-focal.sh
+++ b/build-focal.sh
@@ -15,7 +15,7 @@ wget --no-check-certificate -qO- https://nginx.org/download/nginx-1.18.0.tar.gz 
 # https://www.nginx.com/blog/supporting-http2-google-chrome-users/
 # https://launchpad.net/~fxr/+archive/ubuntu/nginx-alpn/+packages
 mkdir -p openssl
-wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xvz --strip=1 -C openssl
+wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1h.tar.gz | tar -xvz --strip=1 -C openssl
 
 mkdir -p modules/dav-ext
 wget --no-check-certificate -qO- https://github.com/arut/nginx-dav-ext-module/archive/f5e30888a256136d9c550bf1ada77d6ea78a48af.tar.gz | tar -xvz --strip=1 -C modules/dav-ext

--- a/build-jessie.sh
+++ b/build-jessie.sh
@@ -15,7 +15,7 @@ wget --no-check-certificate -qO- https://nginx.org/download/nginx-1.18.0.tar.gz 
 # https://www.nginx.com/blog/supporting-http2-google-chrome-users/
 # https://launchpad.net/~fxr/+archive/ubuntu/nginx-alpn/+packages
 mkdir -p openssl
-wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xvz --strip=1 -C openssl
+wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1h.tar.gz | tar -xvz --strip=1 -C openssl
 
 mkdir -p modules/dav-ext
 wget --no-check-certificate -qO- https://github.com/arut/nginx-dav-ext-module/archive/f5e30888a256136d9c550bf1ada77d6ea78a48af.tar.gz | tar -xvz --strip=1 -C modules/dav-ext

--- a/build-stretch.sh
+++ b/build-stretch.sh
@@ -15,7 +15,7 @@ wget --no-check-certificate -qO- https://nginx.org/download/nginx-1.18.0.tar.gz 
 # https://www.nginx.com/blog/supporting-http2-google-chrome-users/
 # https://launchpad.net/~fxr/+archive/ubuntu/nginx-alpn/+packages
 mkdir -p openssl
-wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xvz --strip=1 -C openssl
+wget --no-check-certificate -qO- https://www.openssl.org/source/openssl-1.1.1h.tar.gz | tar -xvz --strip=1 -C openssl
 
 mkdir -p modules/dav-ext
 wget --no-check-certificate -qO- https://github.com/arut/nginx-dav-ext-module/archive/f5e30888a256136d9c550bf1ada77d6ea78a48af.tar.gz | tar -xvz --strip=1 -C modules/dav-ext

--- a/debian-focal/changelog
+++ b/debian-focal/changelog
@@ -1,3 +1,9 @@
+nginx (1.18.0-1b~focal) focal; urgency=low
+
+  * bump openssl version
+
+ -- kaut <maksimkaut92@gmail.com>  Mon, 09 Nov 2020 20:00:00 +0300
+
 nginx (1.18.0-1a~focal) focal; urgency=low
 
   * 1.18.0

--- a/debian-jessie/changelog
+++ b/debian-jessie/changelog
@@ -1,3 +1,9 @@
+nginx (1.18.0-1b~jessie) jessie; urgency=low
+
+  * bump openssl version
+
+ -- kaut <maksimkaut92@gmail.com>  Mon, 09 Nov 2020 20:00:00 +0300
+
 nginx (1.18.0-1a~jessie) jessie; urgency=low
 
   * 1.18.0

--- a/debian-jessie/rules
+++ b/debian-jessie/rules
@@ -95,6 +95,7 @@ config.status.nginx: config.env.nginx
 		--with-stream_realip_module \
 		--with-stream_ssl_preread_module \
 		--with-openssl=$(BASEDIR)/openssl \
+		--with-openssl-opt=no-afalgeng \
 		--with-http_geoip_module \
 		--with-http_image_filter_module=dynamic \
 		--with-http_xslt_module=dynamic \

--- a/debian-stretch/changelog
+++ b/debian-stretch/changelog
@@ -1,3 +1,9 @@
+nginx (1.18.0-1b~stretch) stretch; urgency=low
+
+  * bump openssl version
+
+ -- kaut <maksimkaut92@gmail.com>  Mon, 09 Nov 2020 20:00:00 +0300
+
 nginx (1.18.0-1a~stretch) stretch; urgency=low
 
   * 1.18.0


### PR DESCRIPTION
Enabled AF_ALG engine breaks openssl build on Debian Jessie.

Signed-off-by: Maksim Kaut <maksimkaut92@gmail.com>