### PR TITLE
add -fno-strict-aliasing due to strict-aliasing warning on old compilers

### DIFF
--- a/debian-jessie/rules
+++ b/debian-jessie/rules
@@ -52,7 +52,7 @@ config.env.%:
 
 config.status.nginx: config.env.nginx
 	cd $(BUILDDIR_nginx) && \
-	CFLAGS="" ./configure \
+	CFLAGS="-fno-strict-aliasing" ./configure \
 		--prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \
 		--modules-path=/usr/lib/nginx/modules \


### PR DESCRIPTION
Signed-off-by: Maksim Kaut <maksimkaut92@gmail.com>